### PR TITLE
Add small sleeps to avoid errors caused by minor timing delays.

### DIFF
--- a/demos/nstack-test-nomodule.yaml
+++ b/demos/nstack-test-nomodule.yaml
@@ -10,6 +10,7 @@ tests:
       - cmd: send
         endpoint: /tsv
         data: "1\t2\t42"
+      - { cmd: sleep, secs: 2 }
       - cmd: log_sink
         regex: \"1!2!42\"
 
@@ -21,6 +22,7 @@ tests:
       - cmd: send
         endpoint: /tsv
         data: "1\t2\t42\n3\t4\t15\n"
+      - { cmd: sleep, secs: 2 }
       - cmd: log_sink
         regex: |
           "\[\[1,2,42\],\[3,4,15\]\]"\s*
@@ -34,6 +36,7 @@ tests:
         endpoint: /tsv
         data:
           [{"b":false, "a":1}, {"a":-1,"b":true}]
+      - { cmd: sleep, secs: 2 }
       - cmd: log_sink
         regex: |
           "a,b\\r\\n1,FALSE\\r\\n-1,TRUE\\r\\n"\s*


### PR DESCRIPTION
Add small sleeps to avoid errors caused by minor timing delays. This should fix some test from failing on Kubernetes due only to a very small delay in output. In the future, we should have a more robust system for expecting outcome that can handle timing delays without relying on explicit sleeps.